### PR TITLE
Add disableResInject option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,10 +128,15 @@ class PreloadPlugin {
               return
             }
             if (this.resourceHints) {
-              htmlPluginData.head = [
-                ...this.resourceHints,
-                ...htmlPluginData.head
-              ]
+              if (this.options.disableResInject) {
+                htmlPluginData.head = this.resourceHints
+                htmlPluginData.body = []
+              } else {
+                htmlPluginData.head = [
+                  ...this.resourceHints,
+                  ...htmlPluginData.head
+                ]
+              }
             }
             return htmlPluginData
           }


### PR DESCRIPTION
Sometimes we just need to preload and disable the original resource. (equivalent to html-webpack-plugin: inject:false)